### PR TITLE
Overrided text color for span inside smooch widget for chat text : #115659277

### DIFF
--- a/widget/assets/css/style.css
+++ b/widget/assets/css/style.css
@@ -108,3 +108,7 @@ input[type=text], input[type=password], input[type=email], #sk-holder #sk-contai
     -ms-user-select: auto !important;
     user-select: auto !important;
 }
+
+#sk-holder span {
+    color: #333 !important;
+}


### PR DESCRIPTION
Earlier the text from slack where not visible due to white color of the chat. I have changed it to default black color now.
